### PR TITLE
improvement: fix warning issue about visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,13 @@ set(CMAKE_CXX_STANDARD 17)
 
 #------------------------------------------------------
 
-# Generate position independant (aka -fPIC) code even for static libs
+# Can be locally overridden using set_target_properties + https://cmake.org/cmake/help/latest/prop_tgt/LANG_VISIBILITY_PRESET.html
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) # Honor the visibility properties for all target types
+
+#------------------------------------------------------
+
+# Generate position independent (aka -fPIC) code even for static libs
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 #------------------------------------------------------

--- a/bindings/Octave/CMakeLists.txt
+++ b/bindings/Octave/CMakeLists.txt
@@ -18,6 +18,13 @@ add_mex_function(NAME mLibKriging
         SOURCES mLibKriging.cpp LinearRegression_binding.cpp LinearRegression_binding.hpp
         LINK_LIBRARIES Kriging OctaveShared)
 
+# https://cmake.org/cmake/help/v3.11/module/GenerateExportHeader.html
+include (GenerateExportHeader)
+GENERATE_EXPORT_HEADER(mLibKriging # generates the export header `lib`_EXPORTS.h automatically
+        BASE_NAME MLIBKRIGING
+        EXPORT_FILE_NAME mlibKriging_exports.h)
+target_include_directories(mLibKriging PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 install(TARGETS mLibKriging
         DESTINATION ${CMAKE_INSTALL_PREFIX}/bindings/Octave
         )

--- a/bindings/Octave/mLibKriging.cpp
+++ b/bindings/Octave/mLibKriging.cpp
@@ -1,5 +1,6 @@
 #include "LinearRegression_binding.hpp"
 #include "mex.h"  // cf https://fr.mathworks.com/help/
+#include "mlibKriging_exports.h"
 #include "tools/MxException.hpp"
 #include "tools/MxMapper.hpp"
 #include "tools/string_hash.hpp"
@@ -26,6 +27,7 @@ mLibKriging help page
  load "y.mat"
  load "X.mat"
  */
+MLIBKRIGING_EXPORT
 void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) try {
   const char* nm = mexFunctionName();
 #ifdef MEX_DEBUG

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -47,7 +47,7 @@ set_target_properties(Kriging PROPERTIES SOVERSION ${KRIGING_VERSION_MAJOR})
 ## target_include_directories (Kriging PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(Kriging
         PUBLIC
-            # path of the headers afterinstallation
+            # path of the headers after installation
             $<INSTALL_INTERFACE:include> # <prefix>/include/libKriging
             # path of the headers before installation
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
pybind11 sets default symbol visibility to hidden.
As it is already supported for Windows, this commit extends this behavior to all lib targets.

Octave binding requires an explicit export to be functional on Linux/MacOS (since visibility is now `hidden` by default).