### PR TITLE
Add support for compiler cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 # set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 
 include(cmake/version.cmake)
+include(cmake/configuration.cmake)
+
+#------------------------------------------------------
 
 project(libKriging
         VERSION ${KRIGING_VERSION}
@@ -29,7 +32,6 @@ endif ()
 
 set(LIBKRIGING_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(LIBKRIGING_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-include(${LIBKRIGING_SOURCE_DIR}/cmake/configuration.cmake)
 
 #------------------------------------------------------
 
@@ -90,6 +92,19 @@ else ()
     string(REGEX MATCH "^(ON|OFF|AUTO)$" VALID_PYTHON_BINDING "${ENABLE_PYTHON_BINDING}")
     if (VALID_PYTHON_BINDING STREQUAL "") # /!\ IF(VALID_PYTHON_BINDING) is false when ENABLE_PYTHON_BINDING is OFF
         logFatalError("Invalid ENABLE_PYTHON_BINDING option '${ENABLE_PYTHON_BINDING}'; choose between ON, OFF and AUTO.")
+    endif ()
+endif ()
+
+#------------------------------------------------------
+
+if (USE_COMPILER_CACHE)
+    # search for requested compiler cache (could be: ccache, sccache...)
+    find_program(COMPILER_CACHE_EXECUTABLE ${USE_COMPILER_CACHE})
+    if (COMPILER_CACHE_EXECUTABLE)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${COMPILER_CACHE_EXECUTABLE}")
+        message(STATUS "Using ${COMPILER_CACHE_EXECUTABLE} as compiler cache for accelerated compilation")
+    else ()
+        logFatalError("Requested compiler cache '${USE_COMPILER_CACHE}' is not available")
     endif ()
 endif ()
 
@@ -277,7 +292,6 @@ endif ()
 #------------------------------------------------------
 
 # search for python-config (for building Python module)
-
 
 # force pybind11 to use the right python interpreter, it could be useful 
 # to define CMAKE_PREFIX_PATH with PYTHON_PREFIX_PATH (cf carma CMake config)

--- a/docs/dev/AllCMakeOptions.md
+++ b/docs/dev/AllCMakeOptions.md
@@ -1,0 +1,22 @@
+List of CMake options to configure libKriging build.
+
+They should be used as `-D<option>=<value>` in `cmake` command line.
+
+| Standard CMake option       | Default value    | Allowed values                                      | Comment                                                     |
+|:----------------------------|:----------------:|:----------------------------------------------------|:------------------------------------------------------------|
+|`CMAKE_BUILD_TYPE`           | `RelWithDebInfo` | `Debug`, `Release`, `RelWithDebInfo`, `MinSizeRel`  |                                                             |
+|`CMAKE_INSTALL_PREFIX`       | `./installed`    |                                                     | path to install libs                                        |
+|`CMAKE_GENERATOR_PLATFORM`   | &lt;empty&gt;    | empty or `x64`                                      | should be set to `x64` on Windows to build 64bits target    |
+
+| libKriging CMake option     | Default value    | Allowed values                                      | Comment                                                     |
+|:----------------------------|:----------------:|:----------------------------------------------------|:------------------------------------------------------------|
+|`EXTRA_SYSTEM_LIBRARY_PATH`  | &lt;empty&gt;    | path                                                | add extra path for finding required libs                    |
+|`LIBKRIGING_BENCHMARK_TESTS` | `OFF`            | `ON`, `OFF`                                         |                                                             |
+|`ENABLE_COVERAGE`            | `OFF`            | `ON`, `OFF`                                         |                                                             |
+|`ENABLE_MEMCHECK`            | `OFF`            | `ON`, `OFF`                                         |                                                             |
+|`ENABLE_STATIC_ANALYSIS`     | `AUTO`           | `ON`, `OFF`, `AUTO` (if available and `Debug` mode) |                                                             |
+|`ENABLE_OCTAVE_BINDING`      | `AUTO`           | `ON`, `OFF`, `AUTO` (if available)                  |                                                             |
+|`ENABLE_PYTHON_BINDING`      | `AUTO`           | `ON`, `OFF`, `AUTO` (if available)                  |                                                             |
+|`USE_COMPILER_CACHE`         | &lt;empty&gt;    | &lt;string&gt;                                      | name of a compiler cache program                            |
+|`BUILD_SHARED_LIBS`          | `ON`             | `ON`, `OFF`                                         |                                                             |
+|`PYTHON_PREFIX_PATH`         | &lt;empty&gt;    | &lt;string&gt;                                      | overrides default python path detection                     |

--- a/docs/dev/FasterCompilation.md
+++ b/docs/dev/FasterCompilation.md
@@ -1,0 +1,21 @@
+In order to speed-up compilations, you can use *compiler cache*.
+
+There are various compiler caches :
+* `ccache` (https://ccache.dev) : the most common in Unix world
+* `sccache` (https://github.com/mozilla/sccache) : a new *challenger* written in Rust and with the support of MSVC
+* `buildcache` (https://github.com/mbitsnbites/buildcache) : 
+* `fastbuild` (https://fastbuild.org)
+
+There are two ways to enable a compiler cache:
+* `cmake -DUSE_COMPILER_CACHE=<your-compiler-cache> <CMAKE_OPTIONS>`
+
+    Example with `ccache`: `cmake -DUSE_COMPILER_CACHE=ccache ..`
+    * The simplest config
+    * Portable even in Windows world
+    * No additional option
+    
+* `CXX="<your-compiler-cache> <your-cxx-compiler>" CC="<your-compiler-cache> <your-c-compiler>" cmake <CMAKE_OPTIONS>`
+
+    Example with `ccache` and GCC: `CXX="ccache g++" CC="ccache gcc" cmake ..`    
+    * Yo have to specify it as a new compiler
+    * You can set additional options in command line  


### PR DESCRIPTION
It can be use to speed-up compilation.

Use `USE_COMPILER_CACHE` as a `cmake` option to define your favorite compiler cache (eg: `ccache`, `sccache`).