### PR TITLE
Fix useless (and conflicting) python3 and octave installations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,12 +185,6 @@ jobs:
       - name: pre-install-windows
         shell: bash
         run: |
-          # add alternative name python3 (default is python)
-          PYTHON_CMD_PATH=$(which python)
-          PYTHON_CMD_DIR=$(dirname "${PYTHON_CMD_PATH}")
-          PYTHON_ALT_CMD_PATH="${PYTHON_CMD_DIR}/python3.exe"
-          ln -s "${PYTHON_CMD_PATH}" "${PYTHON_ALT_CMD_PATH}"
-
           # ~/.R/Makevars will override values in $(R_HOME}/etc$(R_ARCH)/Makeconf
           # Rscript -e 'print(R.home(component="etc"))'
           # Rscript -e 'Sys.getenv("R_HOME")'

--- a/.travis-ci/octave-windows/install.sh
+++ b/.travis-ci/octave-windows/install.sh
@@ -15,7 +15,9 @@ BASEDIR=$(readlink -f "${BASEDIR}")
 choco install -y --no-progress make --version 4.3
 
 if [[ "$ENABLE_OCTAVE_BINDING" == "on" ]]; then
-  choco install -y --no-progress octave.portable
+  # select your version from https://community.chocolatey.org/packages/octave.portable#versionhistory
+  # Don't forget to update loadenv.sh with the related path
+  choco install -y --no-progress octave.portable --version 5.2.0.1
   if [[ ! -e  /c/windows/system32/GLU32.DLL ]]; then
     # add missing GLU32.dll in travis-ci windows image
     # 64bit 10.0.14393.0	161.5 KB	U.S. English	OpenGL Utility Library DLL


### PR DESCRIPTION
Before, python3 executable was called python and a alias was required. This is no more useful.