### PR TITLE
Remove space after operator""

### DIFF
--- a/bindings/Octave/tools/string_hash.hpp
+++ b/bindings/Octave/tools/string_hash.hpp
@@ -19,7 +19,7 @@ size_t fnv_hash(const std::string& input) {
   return fnv_hash(input.c_str());
 }
 
-constexpr size_t operator"" _hash(const char* s, std::size_t) {
+constexpr size_t operator""_hash(const char* s, std::size_t) {
   return fnv_hash(s);
 }
 


### PR DESCRIPTION
For no particular reason I saw Dirk's PR to another repo in my GitHub home page:

https://github.com/marzer/tomlplusplus/pull/263

I searched CRAN for other similarly-affected packages, which includes this one, and am sending along the fix.