### PR TITLE
R binding: fix zzz.R ::: self-call + setOldClass, clean up Kriging examples

### DIFF
--- a/bindings/R/rlibkriging/R/KrigingClass.R
+++ b/bindings/R/rlibkriging/R/KrigingClass.R
@@ -681,6 +681,7 @@ update.Kriging <- function(object, y_u, ..., X_u = NULL, noise_u = NULL, refit =
 #'
 #' outfile = tempfile("k.json") 
 #' save(k,outfile)
+#' unlink(outfile)
 save.Kriging <- function(object, filename, ...) {
     if (length(L <- list(...)) > 0) warnOnDots(L)
     if (!is.character(filename))
@@ -715,6 +716,7 @@ save.Kriging <- function(object, filename, ...) {
 #' save(k,outfile)
 #'
 #' print(load.Kriging(outfile)) 
+#' unlink(outfile)
 load.Kriging <- function(filename, ...) {
     if (length(L <- list(...)) > 0) warnOnDots(L)
     if (!is.character(filename))

--- a/bindings/R/rlibkriging/R/zzz.R
+++ b/bindings/R/rlibkriging/R/zzz.R
@@ -18,10 +18,11 @@
     if (methods::isGeneric("simulate") &&
         !is.null(tryCatch(methods::getGeneric("simulate"), error = function(e) NULL)) &&
         !methods::existsMethod("simulate", "WarpKriging")) {
+      methods::setOldClass("WarpKriging")
       methods::setMethod(
         "simulate", "WarpKriging",
         function(object, nsim = 1, seed = 123, x, will_update = FALSE, ...) {
-          rlibkriging:::simulate.WarpKriging(object,
+          simulate.WarpKriging(object,
                                nsim = nsim, seed = seed, x = x,
                                will_update = will_update, ...)
         },


### PR DESCRIPTION
These are the source-level equivalents of three tweaks that `libKriging/rlibkriging`'s `tools/setup.sh` currently applies **after copying** these files out of `bindings/R/rlibkriging/`. Applying them here removes the need for the downstream patch step (and its `python3` dependency). No behaviour change — the diff is exactly what `setup.sh` produces today.

### `bindings/R/rlibkriging/R/zzz.R`

1. `rlibkriging:::simulate.WarpKriging` → `simulate.WarpKriging`. The closure is defined in the `rlibkriging` namespace, so the unexported S3 method is already in lexical scope; the `:::` self-qualifier only earns an `R CMD check` NOTE ("there are ::: calls to the package's namespace").
2. Add `methods::setOldClass("WarpKriging")` immediately before `methods::setMethod("simulate", "WarpKriging", ...)`, so the S3 class is registered in the dispatch context and load no longer warns `in method for 'simulate' with signature '"WarpKriging"': no definition for class "WarpKriging"`.

### `bindings/R/rlibkriging/R/KrigingClass.R`

3. Append `#' unlink(outfile)` to the `@examples` of `save.Kriging` and `load.Kriging` so a run example leaves no `tempfile("k.json")` behind (`R CMD check --as-cran`).

### Downstream follow-up

Once this is merged and `rlibkriging`'s `src/libK` submodule is bumped, the `zzz.R` / `*KrigingClass.R` patch block in `rlibkriging/tools/setup.sh` becomes redundant and can be deleted (see libKriging/rlibkriging#26, which meanwhile makes that block non-fatal and interpreter-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5w4ZLUZpoHhtsbGyWcVtc